### PR TITLE
Update to 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,10 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv . --no-build-isolation
-  skip: true  # [py<35 or s390x]
+  skip: true  # [py<37 or s390x]
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - pip
@@ -31,7 +30,7 @@ requirements:
     - _openmp_mutex  # [linux]
     - llvm-openmp    # [osx]
     - fftw >=3
-    - numpy {{ numpy }}
+    - numpy
     - scikit-learn >=0.20
     - scipy
     - pynndescent >=0.5.0,<0.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,12 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv . --no-build-isolation
   skip: true  # [py<35 or s390x]
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - pip
@@ -23,20 +24,25 @@ requirements:
     - setuptools
     - wheel
     - cython
-    - fftw
     - {{ pin_compatible('numpy') }}
+    - fftw 3.3.9
   run:
+    - python
     - _openmp_mutex  # [linux]
     - llvm-openmp    # [osx]
-    - fftw
-    - numpy
-    - python
+    - fftw >=3
+    - numpy {{ numpy }}
     - scikit-learn >=0.20
     - scipy
+    - pynndescent >=0.5.0,<0.6.0
 
 test:
   imports:
     - openTSNE
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/pavlin-policar/openTSNE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openTSNE" %}
-{% set version = "0.6.2" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 92ea18afd4e34df8fb536c813c36533de892d96511f6683721003398b4fcf2e9
+  sha256: 51f4dffaa3366ee4a480dd21d5f64eb0fa677248a0c99490aeb8bf311124368c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Extensible, parallel implementations of t-SNE
+  description: |
+    openTSNE is a modular Python implementation of t-Distributed Stochasitc Neighbor Embedding (t-SNE), a popular dimensionality-reduction algorithm for visualizing high-dimensional data sets.
   doc_url: https://opentsne.readthedocs.io
   dev_url: https://github.com/pavlin-policar/openTSNE
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,16 +23,18 @@ requirements:
     - setuptools
     - wheel
     - cython
-    - {{ pin_compatible('numpy') }}
+    - numpy {{ numpy }}
     - fftw 3.3.9
   run:
     - python
     - _openmp_mutex  # [linux]
     - llvm-openmp    # [osx]
-    - fftw >=3
-    - numpy
+    - fftw # bound set through run_exports
+    - {{ pin_compatible('numpy') }}
     - scikit-learn >=0.20
     - scipy
+  run_constrained:
+    - hnswlib >=0.4.0,<0.5.0
     - pynndescent >=0.5.0,<0.6.0
 
 test:


### PR DESCRIPTION
opentsne 1.0.1

**Destination channel:** {defaults}

### Links

- [PKG-4277](https://anaconda.atlassian.net/browse/PKG-4277) 
- [Upstream repository](https://github.com/pavlin-policar/openTSNE/tree/v1.0.1)

### Explanation of changes:

- Updated `version` and `sha256`
- Added `--no-build-isolation`
- Added optional dependency: `pynndescent`
- Pinned `fftw` as version >3 needed
- Added `pip`, `pip check` and `description`

[PKG-4277]: https://anaconda.atlassian.net/browse/PKG-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ