### PR TITLE
Explicit openmp inclusion.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-fixed-test_neighbors-import.patch
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
 
@@ -22,8 +22,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - patch  # [not win]
-    - m2-patch  # [win]
   host:
     - pip
     - python
@@ -32,11 +30,14 @@ requirements:
     - cython
     - numpy {{ numpy }}
     - fftw 3.3.9
+    - libgomp # [linux]
+    - llvm-openmp    # [osx or (win and arm64)]
+    - vcomp14        # [win and x86_64]
   run:
     - python
-    #_openmp_mutex AND llvm-openmp needs to avoid run_exports problem
-    - _openmp_mutex  # [linux]
-    - llvm-openmp    # [osx]
+    - libgomp # [linux]
+    - llvm-openmp    # [osx or (win and arm64)]
+    - vcomp14        # [win and x86_64]
     - numpy >=1.16.6
     - scikit-learn >=0.20
     - scipy


### PR DESCRIPTION
opentsne openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14732](https://anaconda.atlassian.net/browse/PKG-14732) 


### Explanation of changes:

- Bump build number
- Remove *patch
- Explicitly pin openmp_impl being used. 

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)

[PKG-14732]: https://anaconda.atlassian.net/browse/PKG-14732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ